### PR TITLE
README: update info for MacPorts packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ See the release section on GitHub.
     * [my website](http://martchus.no-ip.biz/website/page.php?name=programming) also contains an occasionally
       updated archive with a dynamically linked executable
 * Mac OS X/macOS
-    * package syncthingtray-devel is available from [MacPorts](https://www.macports.org/ports.php?by=name&substr=syncthingtray-devel)
+    * package syncthingtray is available from [MacPorts](https://ports.macports.org/port/syncthingtray/)
 
 ## Build instructions
 The application depends on [c++utilities](https://github.com/Martchus/cpp-utilities) and


### PR DESCRIPTION
From https://github.com/Martchus/syncthingtray/issues/37#issuecomment-513434843

> When a stable version of syncthingtray is out, I will switch to it.

Here you go :)

I may not continue to maintain the -devel version in the future, so I propose not to advertise it here.

Also switches to the new "ports" website from GSoC 2019 of MacPorts [1].

[1] https://trac.macports.org/wiki/SummerOfCode/2019#webapp