### PR TITLE
Fix build with systemd disabled

### DIFF
--- a/plasmoid/lib/syncthingapplet.cpp
+++ b/plasmoid/lib/syncthingapplet.cpp
@@ -226,7 +226,7 @@ void SyncthingApplet::setCurrentConnectionConfigIndex(int index)
     const auto systemdConsideredForReconnect
         = settings.systemd.apply(m_connection, currentConnectionConfig(), reconnectRequired).consideredForReconnect;
 #else
-    const auto systemdRelevantForReconnect = false;
+    const auto systemdConsideredForReconnect = false;
 #endif
     if (!systemdConsideredForReconnect && (reconnectRequired || !m_connection.isConnected())) {
         m_connection.reconnect();


### PR DESCRIPTION
Build with systemd disabled fails because systemdConsideredForReconnect is not defined. I think it was just a typo here, so fix that.