### PR TITLE
Fix cmakelists to find correct qtutilities name

### DIFF
--- a/fileitemactionplugin/CMakeLists.txt
+++ b/fileitemactionplugin/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(c++utilities${CONFIGURATION_PACKAGE_SUFFIX} 5.0.0 REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${CPP_UTILITIES_MODULE_DIRS})
 
 # find qtutilities
-find_package(qtutilities${CONFIGURATION_PACKAGE_SUFFIX} 6.0.0 REQUIRED)
+find_package(qtutilities${CONFIGURATION_PACKAGE_SUFFIX_QTUTILITIES} 6.0.0 REQUIRED)
 use_qt_utilities()
 
 # find backend libraries


### PR DESCRIPTION
Hit this when building syncthingtray-qt6 1.1.9 from AUR. Cmake chose to find qtutilities instead of qtutilities-qt6 and failed to build.