### PR TITLE
Fix typo ("settinngs" -> "settings")

### DIFF
--- a/widgets/settings/settingsdialog.cpp
+++ b/widgets/settings/settingsdialog.cpp
@@ -566,7 +566,7 @@ QWidget *IconsOptionPage::setupWidget()
     case Context::System:
         widget->setWindowTitle(QCoreApplication::translate("QtGui::IconsOptionPageBase", "System icons"));
         ui()->contextLabel->setText(QCoreApplication::translate(
-            "QtGui::IconsOptionPageBase", "These icon settinngs are used for the system tray icon and the notifications."));
+            "QtGui::IconsOptionPageBase", "These icon settings are used for the system tray icon and the notifications."));
         ui()->contextCheckBox->setText(QCoreApplication::translate("QtGui::IconsOptionPageBase", "Use same settings as for UI icons"));
         break;
     }

--- a/widgets/translations/syncthingwidgets_cs_CZ.ts
+++ b/widgets/translations/syncthingwidgets_cs_CZ.ts
@@ -562,7 +562,7 @@
     </message>
     <message>
         <location filename="../settings/settingsdialog.cpp" line="568"/>
-        <source>These icon settinngs are used for the system tray icon and the notifications.</source>
+        <source>These icon settings are used for the system tray icon and the notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/widgets/translations/syncthingwidgets_de_DE.ts
+++ b/widgets/translations/syncthingwidgets_de_DE.ts
@@ -660,7 +660,7 @@
     </message>
     <message>
         <location filename="../settings/settingsdialog.cpp" line="568"/>
-        <source>These icon settinngs are used for the system tray icon and the notifications.</source>
+        <source>These icon settings are used for the system tray icon and the notifications.</source>
         <translation>Diese Icon-Einstellungen werden für das System-Tray-Icon und Benachrichtigungen verwendet.</translation>
     </message>
     <message>

--- a/widgets/translations/syncthingwidgets_en_US.ts
+++ b/widgets/translations/syncthingwidgets_en_US.ts
@@ -561,7 +561,7 @@
     </message>
     <message>
         <location filename="../settings/settingsdialog.cpp" line="568"/>
-        <source>These icon settinngs are used for the system tray icon and the notifications.</source>
+        <source>These icon settings are used for the system tray icon and the notifications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/widgets/translations/syncthingwidgets_zh_CN.ts
+++ b/widgets/translations/syncthingwidgets_zh_CN.ts
@@ -560,7 +560,7 @@
     </message>
     <message>
         <location filename="../settings/settingsdialog.cpp" line="568"/>
-        <source>These icon settinngs are used for the system tray icon and the notifications.</source>
+        <source>These icon settings are used for the system tray icon and the notifications.</source>
         <translation>这些图标设置用于系统托盘图标和通知。</translation>
     </message>
     <message>


### PR DESCRIPTION
In the "System icons" tab of the "Tray" settings menu, the word "settings" is misspelled as "settings". This small pull  request fixes that.