### PR TITLE
Make Debian (and derivatives) section more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,9 +242,10 @@ See the release section on GitHub.
         * `syncthingplasmoid`: applet/plasmoid for Plasma desktop
         * `syncthingfileitemaction`: Dolphin/KIO integration
         * `syncthingctl`: command-line interface
-* Debian
-    * the packages syncthingtray and syncthingtray-kde-plasma are available in official repositories
-    * see their [tracker](https://tracker.debian.org/pkg/syncthingtray) for available versions and other details
+* Debian 12 "bookworm" and its derivatives (Ubuntu, Pop!_OS, Neon, etc.)
+    * `sudo apt install syncthingtray-kde-plasma` if using KDE Plasma;
+      otherwise, `sudo apt install syncthingtray`.  Please test installation from a Software Centre such as [GNOME Software](https://apps.gnome.org/en-GB/app/org.gnome.Software) or [Discover](https://apps.kde.org/en-gb/discover/).
+    * [backport](https://backports.debian.org/) to Debian 11 "bullseye" available on request.
 * Exherbo
     * packages for my other project "Tag Editor" and dependencies could serve as a base and are provided
       by [the platypus repository](https://git.exherbo.org/summer/packages/media-sound/tageditor)


### PR DESCRIPTION
* Include the conventional copy & paste installation instructions that
most Ubuntu (and derivatives) users expect.

* Request that users test their operating system's app store, because
a potential Appstream bug would be highly visible and would negatively
affect initial user impressions.  Such a hypothetical bug should
ideally be found and fixed before Ubuntu 22.10's freeze, and certainly
before Debian 12's.

* Mention the backports repository, because otherwise users will
manually install packages for sid/unstable/testing/bookworm/12 onto
stable/bullseye/11.  These packages will be nonfunctional, will
malfunction, or will break the other package's dependencies.

* Remove link to Developer Information Tracker, because it may also
mislead users into creating FrankenDebian, and because it is not
supposed to be a user-facing page.