### PR TITLE
autostart: Enable setting via cmake Exec= path

### DIFF
--- a/widgets/CMakeLists.txt
+++ b/widgets/CMakeLists.txt
@@ -116,6 +116,12 @@ if (SYNCTHING_WIDGETS_LOG_JAVASCRIPT_CONSOLE)
     message(WARNING "JavaScript console of web view will be logged to stderr")
 endif ()
 
+# configure autostart .desktop file exec path
+option(AUTOSTART_EXEC_PATH "Set the Exec= path for Linux' autostart/syncthingtray.desktop file - useful for Nix & Guix")
+if (AUTOSTART_EXEC_PATH)
+    add_compile_definitions(AUTOSTART_EXEC_PATH="${AUTOSTART_EXEC_PATH}")
+endif()
+
 # link also explicitly against the following Qt modules
 list(APPEND ADDITIONAL_QT_MODULES Network Concurrent)
 

--- a/widgets/CMakeLists.txt
+++ b/widgets/CMakeLists.txt
@@ -117,10 +117,15 @@ if (SYNCTHING_WIDGETS_LOG_JAVASCRIPT_CONSOLE)
 endif ()
 
 # configure autostart .desktop file exec path
-option(AUTOSTART_EXEC_PATH "Set the Exec= path for Linux' autostart/syncthingtray.desktop file - useful for Nix & Guix")
+set(AUTOSTART_EXEC_PATH
+    ""
+    CACHE STRING "Set the Exec= path for Linux' autostart/syncthingtray.desktop file - useful for Nix & Guix")
 if (AUTOSTART_EXEC_PATH)
-    add_compile_definitions(AUTOSTART_EXEC_PATH="${AUTOSTART_EXEC_PATH}")
-endif()
+    set_property(
+        SOURCE settings/settingsdialog.cpp
+        APPEND
+        PROPERTY COMPILE_DEFINITIONS SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH="${AUTOSTART_EXEC_PATH}")
+endif ()
 
 # link also explicitly against the following Qt modules
 list(APPEND ADDITIONAL_QT_MODULES Network Concurrent)

--- a/widgets/settings/settingsdialog.cpp
+++ b/widgets/settings/settingsdialog.cpp
@@ -802,8 +802,8 @@ bool setAutostartEnabled(bool enabled)
         desktopFile.write("[Desktop Entry]\n"
                           "Name=" APP_NAME "\n"
                           "Exec=\"");
-#if defined(AUTOSTART_EXEC_PATH)
-        desktopFile.write(qEnvironmentVariable("APPIMAGE", AUTOSTART_EXEC_PATH).toUtf8().data());
+#if defined(SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH)
+        desktopFile.write(qEnvironmentVariable("APPIMAGE", SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH).toUtf8().data());
 #else
         desktopFile.write(qEnvironmentVariable("APPIMAGE", QCoreApplication::applicationFilePath()).toUtf8().data());
 #endif

--- a/widgets/settings/settingsdialog.cpp
+++ b/widgets/settings/settingsdialog.cpp
@@ -802,7 +802,11 @@ bool setAutostartEnabled(bool enabled)
         desktopFile.write("[Desktop Entry]\n"
                           "Name=" APP_NAME "\n"
                           "Exec=\"");
+#if defined(AUTOSTART_EXEC_PATH)
+        desktopFile.write(qEnvironmentVariable("APPIMAGE", AUTOSTART_EXEC_PATH).toUtf8().data());
+#else
         desktopFile.write(qEnvironmentVariable("APPIMAGE", QCoreApplication::applicationFilePath()).toUtf8().data());
+#endif
         desktopFile.write("\" qt-widgets-gui --single-instance\nComment=" APP_DESCRIPTION "\n"
                           "Icon=" PROJECT_NAME "\n"
                           "Type=Application\n"

--- a/widgets/settings/settingsdialog.cpp
+++ b/widgets/settings/settingsdialog.cpp
@@ -802,11 +802,10 @@ bool setAutostartEnabled(bool enabled)
         desktopFile.write("[Desktop Entry]\n"
                           "Name=" APP_NAME "\n"
                           "Exec=\"");
-#if defined(SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH)
-        desktopFile.write(qEnvironmentVariable("APPIMAGE", SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH).toUtf8().data());
-#else
-        desktopFile.write(qEnvironmentVariable("APPIMAGE", QCoreApplication::applicationFilePath()).toUtf8().data());
+#ifndef SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH
+#define SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH QCoreApplication::applicationFilePath()
 #endif
+        desktopFile.write(qEnvironmentVariable("APPIMAGE", SYNCTHINGWIDGETS_AUTOSTART_EXEC_PATH).toUtf8().data());
         desktopFile.write("\" qt-widgets-gui --single-instance\nComment=" APP_DESCRIPTION "\n"
                           "Icon=" PROJECT_NAME "\n"
                           "Type=Application\n"


### PR DESCRIPTION
With this patch, I managed to make syncthingtray create the file:

```desktop
[Desktop Entry]
Name=Syncthing Tray
Exec="/run/current-system/sw/bin/syncthingtray" qt-widgets-gui --single-instance
Comment=Tray application for Syncthing
Icon=syncthingtray
Type=Application
Terminal=false
X-GNOME-Autostart-Delay=0
X-GNOME-Autostart-enabled=true
```