### PR TITLE
Correct Debian (and derivatives) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,15 +420,15 @@ See the [release section on GitHub](https://github.com/Martchus/syncthingtray/re
         * `syncthingfileitemaction`/`syncthingfileitemaction-qt6`: Dolphin/KIO integration
         * `syncthingctl`/`syncthingctl-qt6`: command-line interface
 * Debian and its derivatives like Ubuntu
-    * *Some* versions of Debian provide packages for Syncthing Tray. Those packages *may* be available on *some* versions
-      of *some* Debian derivats as well (e.g. Ubuntu, Pop!_OS, …). KDE neon is known to **not** support the packages. If
-      your concrete distribution/version does not provide packages you will have to look into other options.
+    * Every Debian release since 12 (bookworm) has packages for Syncthing Tray that are supported by Debian. These packages *may*
+      also be available on *some* Debian derivatives as well (e.g. Ubuntu, Pop!_OS, etc). KDE neon is known to **not** support
+      these packages. If your distribution/version does not have the packages then you will have to look into other options.
     * Install packages via:
         * `sudo apt install syncthingtray` for the generic tray application
-        * `sudo apt install syncthingtray-kde-plasma` for the Plasmoid and other KDE integrations which is recommended if
+        * `sudo apt install syncthingtray-kde-plasma` for the Plasmoid and other KDE integrations, which is recommended when
           using KDE Plasma
     * Installation from a software center such as [GNOME Software](https://apps.gnome.org/en-GB/app/org.gnome.Software) or
-      [Discover](https://apps.kde.org/en-gb/discover/) should be possible as well.
+      [Discover](https://apps.kde.org/en-gb/discover/) is also supported by Debian.
 * Exherbo
     * packages for my other project "Tag Editor" and dependencies could serve as a base and are provided
       by [the platypus repository](https://git.exherbo.org/summer/packages/media-sound/tageditor)


### PR DESCRIPTION
Fix various factual errors, typos, and grammatical issues.  Promote software store installation method because it has now been tested by thousands of Debian 12 (bookworm) and Debian 13 (trixie) users.