### PR TITLE
Trust all certificates within the specified HTTPS certificate file

### DIFF
--- a/syncthingconnector/syncthingconnection.cpp
+++ b/syncthingconnector/syncthingconnection.cpp
@@ -1104,7 +1104,7 @@ bool SyncthingConnection::loadSelfSignedCertificate(const QUrl &url)
         emit error(tr("Unable to load certificate used by Syncthing."), SyncthingErrorCategory::OverallConnection, QNetworkReply::NoError);
         return false;
     }
-    m_expectedSslErrors = SyncthingConnectionSettings::compileSslErrors(certs.at(0));
+    m_expectedSslErrors = SyncthingConnectionSettings::compileSslErrors(certs);
     // keep track of the dynamically determined certificate path for handleSslErrors()
     if (m_certificatePath.isEmpty()) {
         m_dynamicallyDeterminedCertificatePath = certPath;

--- a/syncthingconnector/syncthingconnectionsettings.cpp
+++ b/syncthingconnector/syncthingconnectionsettings.cpp
@@ -21,6 +21,17 @@ QList<QSslError> SyncthingConnectionSettings::compileSslErrors(const QSslCertifi
     // clang-format on
 }
 
+QList<QSslError> SyncthingConnectionSettings::compileSslErrors(const QList<QSslCertificate> &trustedCerts)
+{
+    auto sslErrors = QList<QSslError>();
+    for (const auto &trustedCert : trustedCerts) {
+        if (!trustedCert.isNull()) {
+            sslErrors.append(compileSslErrors(trustedCert));
+        }
+    }
+    return sslErrors;
+}
+
 bool SyncthingConnectionSettings::loadHttpsCert()
 {
     expectedSslErrors.clear();
@@ -33,7 +44,7 @@ bool SyncthingConnectionSettings::loadHttpsCert()
     }
 
     httpCertLastModified = QFileInfo(httpsCertPath).lastModified();
-    expectedSslErrors = compileSslErrors(certs.at(0));
+    expectedSslErrors = compileSslErrors(certs);
     return true;
 }
 #endif

--- a/syncthingconnector/syncthingconnectionsettings.h
+++ b/syncthingconnector/syncthingconnectionsettings.h
@@ -65,6 +65,7 @@ struct LIB_SYNCTHING_CONNECTOR_EXPORT SyncthingConnectionSettings {
     bool autoConnect = false;
 #ifndef QT_NO_SSL
     static QList<QSslError> compileSslErrors(const QSslCertificate &trustedCert);
+    static QList<QSslError> compileSslErrors(const QList<QSslCertificate> &trustedCerts);
     bool loadHttpsCert();
 #endif
     void storeToJson(QJsonObject &object);


### PR DESCRIPTION
When the file at `httpsCertPath` contains a chain (e.g. a root CA plus an intermediate CA), only the first certificate was taken into account: `loadHttpsCert()` passed `certs.at(0)` to `compileSslErrors()`.

With a private PKI that uses an intermediate CA, Qt reports `UnableToGetLocalIssuerCertificate` for the *intermediate* certificate, because its issuer (the root CA) is unknown. If the root CA happens to come first in the PEM file, the expected error does not match the reported one and connecting fails with "The issuer certificate of a locally looked up certificate could not be found (11)".

This compiles the expected SSL errors for every certificate contained in the file instead. The same is done in `loadSelfSignedCertificate()` for consistency.

Note: I have not built this locally as I do not have the required toolchain set up. I verified the underlying cause by reordering the certificates within the PEM file so the intermediate CA comes first, which makes the connection work with the current code.